### PR TITLE
updated cmake with IREE_TARGET_BACKEND_EXSLERATE

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -442,6 +442,16 @@ cmake_dependent_option(IREE_TARGET_BACKEND_VULKAN_SPIRV "Enables the 'vulkan-spi
 
 # Default target backends that are not yet fully supported but are being brought up.
 cmake_dependent_option(IREE_TARGET_BACKEND_ROCM "Enables the 'rocm' compiler target backend" OFF ${IREE_BUILD_COMPILER} OFF)
+option(IREE_TARGET_BACKEND_EXSLERATE "Enables the 'exsleratev2' compiler target backend" OFF)
+
+if(IREE_TARGET_BACKEND_EXSLERATE)
+  set(
+    IREE_CMAKE_PLUGIN_PATHS
+    "${CMAKE_CURRENT_SOURCE_DIR}/../../"
+    CACHE STRING "Path to plugins"
+    FORCE
+  )
+endif()
 
 # Supported target backends that are only available on certain platforms.
 set(IREE_TARGET_BACKEND_CUDA_DEFAULT ${IREE_TARGET_BACKEND_DEFAULTS})


### PR DESCRIPTION
Flag to enable build for the Exslerate compiler as a target backend

- Vimal William