### PR TITLE
[Compiler] Added the TARGET_BACKEND Flag to cmake & fixed the bug for detecting generic conv

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -443,6 +443,17 @@ cmake_dependent_option(IREE_TARGET_BACKEND_VULKAN_SPIRV "Enables the 'vulkan-spi
 # Default target backends that are not yet fully supported but are being brought up.
 cmake_dependent_option(IREE_TARGET_BACKEND_ROCM "Enables the 'rocm' compiler target backend" OFF ${IREE_BUILD_COMPILER} OFF)
 
+cmake_dependent_option(IREE_TARGET_BACKEND_EXSLERATEV2 "Enables the 'exsleratev2' compiler target backend" ${IREE_TARGET_BACKEND_DEFAULTS} ${IREE_BUILD_COMPILER} OFF)
+
+if(IREE_TARGET_BACKEND_EXSLERATEV2)
+  set(
+    IREE_CMAKE_PLUGIN_PATHS
+    "${CMAKE_CURRENT_SOURCE_DIR}/../../"
+    CACHE STRING "Path to plugins"
+    FORCE
+  )
+endif()
+
 # Supported target backends that are only available on certain platforms.
 set(IREE_TARGET_BACKEND_CUDA_DEFAULT ${IREE_TARGET_BACKEND_DEFAULTS})
 if(NOT IREE_CUDA_AVAILABLE)

--- a/compiler/src/iree/compiler/Codegen/ExternalInterfaces/CPUEncodingExternalModels.cpp
+++ b/compiler/src/iree/compiler/Codegen/ExternalInterfaces/CPUEncodingExternalModels.cpp
@@ -455,9 +455,9 @@ FailureOr<Operation *> lowerConvolutionOpWithEncoding(
       ValueRange{newResult}, convertedMaps, convertedIterType,
       [&](OpBuilder &nestedBuilder, Location nestedLoc, ValueRange args) {
         Value mul =
-            nestedBuilder.create<arith::MulFOp>(nestedLoc, args[0], args[1]);
+            nestedBuilder.create<arith::MulIOp>(nestedLoc, args[0], args[1]);
         Value add =
-            nestedBuilder.create<arith::AddFOp>(nestedLoc, mul, args[2]);
+            nestedBuilder.create<arith::AddIOp>(nestedLoc, mul, args[2]);
         nestedBuilder.create<linalg::YieldOp>(nestedLoc, add);
       });
   return result;

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Utils/MatchUtils.cpp
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Utils/MatchUtils.cpp
@@ -554,9 +554,9 @@ isEXSLTiledConvolutionInterfaceImpl(Operation *op) {
   bool hasadd = false;
 
   for (auto &op : body.getOperations()) {
-    if (isa<arith::MulFOp>(op))
+    if (isa<arith::MulIOp>(op))
       hasmul = true;
-    if (isa<arith::AddFOp>(op))
+    if (isa<arith::AddIOp>(op))
       hasadd = true;
   }
 


### PR DESCRIPTION
This PR fixes:

The bug is that it fails to detect the int8 convolution operations, as the operation in the body is performed in FP32.
Also updated the CMake flag for exsleratev2 target backend